### PR TITLE
use BSpline instead of spline to match newer version of scipy

### DIFF
--- a/image_funcs.py
+++ b/image_funcs.py
@@ -1,4 +1,4 @@
-from scipy.interpolate import spline, interp1d
+from scipy.interpolate import BSpline, interp1d
 from scipy.signal import hilbert
 from numpy.fft import fft, ifft
 from math import pi


### PR DESCRIPTION
Let this program executable with newer scipy (1.8.1)